### PR TITLE
Update steamcommunity-302.json

### DIFF
--- a/bucket/steamcommunity-302.json
+++ b/bucket/steamcommunity-302.json
@@ -1,11 +1,11 @@
 {
-    "version": "13.0.00",
+    "version": "13.0.01",
     "description": "Reverse proxy tool to access Steam Community in mainland China.",
     "homepage": "https://www.dogfight360.com/blog/18682/",
     "license": "Freeware",
-    "url": "https://www.dogfight360.com/blog/wp-content/uploads/2025/02/steamcommunity_302_V13.0.00.zip",
-    "hash": "42f10030e565b6b3fe4e681e0ada875149138dfb277f0c9c0618671d204b07ec",
-    "extract_dir": "steamcommunity_302_V13.0.00/Steamcommunity_302",
+    "url": "https://www.dogfight360.com/blog/wp-content/uploads/2025/03/steamcommunity_302_V13.0.01_fix.zip",
+    "hash": "27146ccb59aba7a53f6d17288ffd9e0ebe81ca6c13ce95d2e20e48055cad930d",
+    "extract_dir": "steamcommunity_302_V13.0.01/Steamcommunity_302",
     "shortcuts": [
         [
             "steamcommunity_302.exe",
@@ -14,10 +14,10 @@
     ],
     "depends": "main/7zip",
     "checkver": {
-        "regex": "uploads/(?<date>[\\d/]+)/steamcommunity_302_V([\\d.]+).zip"
+        "regex": "uploads/(?<date>[\\d/]+)/steamcommunity_302_V([\\d.]+)(?<Suffix>.+)?.zip"
     },
     "autoupdate": {
-        "url": "https://www.dogfight360.com/blog/wp-content/uploads/$matchDate/steamcommunity_302_V$version.zip",
+        "url": "https://www.dogfight360.com/blog/wp-content/uploads/$matchDate/steamcommunity_302_V$version$matchSuffix.zip",
         "extract_dir": "steamcommunity_302_V$version/Steamcommunity_302"
     }
 }


### PR DESCRIPTION
早上起来一看，怎么在反向更新

原来羽翼城老哥加了个`_fix`后缀，正则没匹配上
